### PR TITLE
Fix Qt version detection for versions greater 5.10

### DIFF
--- a/tremotesf.pro
+++ b/tremotesf.pro
@@ -1,5 +1,7 @@
-lessThan(QT_VERSION, 5.2) {
-    error("Requires Qt 5.2 or greather")
+lessThan(QT_MAJOR_VERSION, 5) {
+    lessThan(QT_MINOR_VERSION, 2) {
+        error("Requires Qt 5.2 or greather")
+    }
 }
 
 VERSION = 1.3.2


### PR DESCRIPTION
I do not remember working with qmake before, so I have no idea if this is the right way to do this.