### PR TITLE
Change X-GNOME-SingleWindow key to SingleMainWindow

### DIFF
--- a/data/desktop/org.equeim.Tremotesf.desktop.in
+++ b/data/desktop/org.equeim.Tremotesf.desktop.in
@@ -7,5 +7,5 @@ Icon=org.equeim.Tremotesf
 Exec=tremotesf %U
 StartupNotify=true
 StartupWMClass=tremotesf
-X-GNOME-SingleWindow=true
+SingleMainWindow=true
 MimeType=application/x-bittorrent;x-scheme-handler/magnet;


### PR DESCRIPTION
X-GNOME-SingleWindow was upstreamed to be an XDG spec with the name "SingleMainWindow" in https://gitlab.freedesktop.org/xdg/xdg-specs/-/merge_requests/53