### PR TITLE
Set console output codepage on Windows

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -50,6 +50,10 @@
 
 int main(int argc, char** argv)
 {
+#ifdef Q_OS_WIN
+    SetConsoleOutputCP(GetACP());
+#endif
+
     // Setup handler for UNIX signals or Windows console handler
     tremotesf::SignalHandler::setupHandlers();
 


### PR DESCRIPTION
On Windows, QDebug prints text in current ANSI codepage.
However, the actual codepage that console uses to display text
is console output codepage, and it not neccessarily the same as
current ANSI codepage. Change console output codepage to current ANSI
codepage manually to fix text display in Windows console.