### PR TITLE
Improve CMakePresets.json for Visual Studio integration

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -66,7 +66,7 @@ jobs:
       uses: equeim/action-cmake-build@v5.2
       with:
         # We set VCPKG_INSTALLED_DIR variable to share vcpkg prefix between Debug and Release configs
-        cmake-arguments: --preset windows --toolchain '${{env.VCPKG_ROOT}}\scripts\buildsystems\vcpkg.cmake' -D VCPKG_INSTALLED_DIR='${{github.workspace}}\vcpkg_installed'
+        cmake-arguments: --preset windows
         install: true
 
     - name: Archive debug artifacts
@@ -90,4 +90,4 @@ jobs:
         name: vcpkg-logs
         path: |
           ${{env.VCPKG_ROOT}}\buildtrees\*\*.log
-          .\build\vcpkg-manifest-install.log
+          .\build-*\vcpkg-manifest-install.log

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,8 @@
-/build
-/build-*
+/.vs
+/installroot
+/out
+/RPMS
+/vcpkg_installed
 *.list
 *.user
 *.user.*
-/RPMS
-/installroot

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -3,52 +3,116 @@
   "configurePresets": [
     {
       "name": "default",
-      "displayName": "Default preset",
+      "displayName": "Default",
       "generator": "Ninja",
-      "binaryDir": "build",
-      "installDir": "install",
-      "cacheVariables": {
-        "CMAKE_BUILD_TYPE": "Debug"
-      },
+      "binaryDir": "${sourceDir}/out/build/${presetName}",
+      "installDir": "${sourceDir}/out/install/${presetName}",
       "warnings": {
         "dev": true,
         "deprecated": true
       }
     },
     {
-      "name": "default-multi",
+      "name": "default-debug",
+      "displayName": "Default Debug",
       "inherits": "default",
-      "displayName": "Default multi-config preset",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Debug"
+      }
+    },
+    {
+      "name": "default-release",
+      "displayName": "Default Release",
+      "inherits": "default",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Release"
+      }
+    },
+    {
+      "name": "default-multi",
+      "displayName": "Multi-config",
+      "inherits": "default",
       "generator": "Ninja Multi-Config",
       "cacheVariables": {
-        "CMAKE_BUILD_TYPE": "",
         "CMAKE_CONFIGURATION_TYPES": "Debug;Release"
       }
     },
     {
       "name": "windows",
+      "displayName": "Windows",
       "inherits": "default",
-      "displayName": "Windows preset",
       "condition": {
         "type": "equals",
         "lhs": "${hostSystemName}",
         "rhs": "Windows"
       },
+      "architecture": {
+        "value": "x64",
+        "strategy": "external"
+      },
       "cacheVariables": {
-        "CMAKE_CXX_COMPILER": "cl.exe",
         "CMAKE_INTERPROCEDURAL_OPTIMIZATION_RELEASE": "ON",
+        "VCPKG_INSTALLED_DIR": "${sourceDir}/vcpkg_installed",
         "VCPKG_TARGET_TRIPLET": "x64-windows-static",
         "VCPKG_HOST_TRIPLET": "x64-windows-static",
         "VCPKG_INSTALL_OPTIONS": "--disable-metrics;--clean-after-build"
+      },
+      "toolchainFile": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake",
+      "vendor": {
+        "microsoft.com/VisualStudioSettings/CMake/1.0": {
+          "hostOS": [ "Windows" ]
+        }
+      }
+    },
+    {
+      "name": "windows-debug",
+      "displayName": "Windows Debug",
+      "inherits": "windows",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Debug"
+      }
+    },
+    {
+      "name": "windows-release",
+      "displayName": "Windows Release",
+      "inherits": "windows",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Release"
       }
     },
     {
       "name": "windows-multi",
+      "displayName": "Multi-config Windows",
       "inherits": [
         "default-multi",
         "windows"
-      ],
-      "displayName": "Windows multi-config preset"
+      ]
+    }
+  ],
+  "buildPresets": [
+    {
+      "name": "debug",
+      "displayName": "Debug",
+      "configurePreset": "default-multi",
+      "configuration": "Debug"
+    },
+    {
+      "name": "release",
+      "displayName": "Release",
+      "configurePreset": "default-multi",
+      "configuration": "Release"
+    },
+    {
+      "name": "windows-debug",
+      "displayName": "Debug",
+      "configurePreset": "windows-multi",
+      "configuration": "Debug"
+    },
+    {
+      "name": "windows-release",
+      "displayName": "Release",
+      "configurePreset": "windows-multi",
+      "configuration": "Release"
     }
   ]
 }


### PR DESCRIPTION
Add separate configure presets for Debug and Release build types.

Adjust binaryDir and installDir so that different present will have
independent directories.

Set shared VCPKG_INSTALLED_DIR outside of binaryDir for single-config
Windows presets.

Automatically load vcpkg toolchain file using VCPKG_ROOT environment
variable.

Remove setting CMAKE_CXX_COMPILER to relative path to cl.exe since
it seem to confuse Visual Studio.

Add Debug/Release build presets for multi-config configure presets
(they seem to be very buggy in Visual Studio though).