### PR TITLE
Don't join threads in destructors of static objects

### DIFF
--- a/src/tremotesf/startup/main.cpp
+++ b/src/tremotesf/startup/main.cpp
@@ -33,9 +33,17 @@ int main(int argc, char** argv)
     if constexpr (isTargetOsWindows) {
         windowsInitPrelude();
     }
+    const auto preludeScopeGuard = QScopeGuard([] {
+        if constexpr (isTargetOsWindows) {
+            windowsDeinitPrelude();
+        }
+    });
 
     // Setup handler for UNIX signals or Windows console handler
-    signalhandler::setupSignalHandlers();
+    signalhandler::initSignalHandler();
+    const auto signalHandlerGuard = QScopeGuard([] {
+        signalhandler::deinitSignalHandler();
+    });
 
     //
     // Command line parsing

--- a/src/tremotesf/startup/main_windows.cpp
+++ b/src/tremotesf/startup/main_windows.cpp
@@ -91,7 +91,7 @@ namespace tremotesf {
     }
 
     void windowsInitPrelude() {
-        qInstallMessageHandler(windowsMessageHandler);
+        initWindowsMessageHandler();
         std::set_terminate(onTerminate);
     }
 
@@ -122,6 +122,10 @@ namespace tremotesf {
         } catch (const winrt::hresult_error& e) {
             logWarning("winrt::uninit_apartment failed: {}", e);
         }
+    }
+
+    void windowsDeinitPrelude() {
+        deinitWindowsMessageHandler();
     }
 }
 

--- a/src/tremotesf/startup/main_windows.h
+++ b/src/tremotesf/startup/main_windows.h
@@ -10,6 +10,7 @@ namespace tremotesf {
 	void windowsInitWinrt();
 	void windowsInitApplication();
 	void windowsDeinitWinrt();
+	void windowsDeinitPrelude();
 }
 
 #endif // TREMOTEST_MAIN_WINDOWS_H

--- a/src/tremotesf/startup/signalhandler.h
+++ b/src/tremotesf/startup/signalhandler.h
@@ -8,7 +8,8 @@
 namespace tremotesf
 {
     namespace signalhandler {
-        void setupSignalHandlers();
+        void initSignalHandler();
+        void deinitSignalHandler();
         bool isExitRequested();
     }
 }

--- a/src/tremotesf/startup/signalhandler_windows.cpp
+++ b/src/tremotesf/startup/signalhandler_windows.cpp
@@ -57,12 +57,22 @@ namespace tremotesf::signalhandler
         }
     }
 
-    void setupSignalHandlers()
+    void initSignalHandler()
     {
         try {
             checkWin32Bool(SetConsoleCtrlHandler(&consoleHandler, TRUE), "SetConsoleCtrlHandler");
+            logDebug("signalhandler: added console signal handler");
         } catch (const std::system_error& e) {
-            logWarningWithException(e, "Failed to setup signal handler");
+            logWarningWithException(e, "signalhandler: failed to add console signal handler");
+        }
+    }
+
+    void deinitSignalHandler() {
+        try {
+            checkWin32Bool(SetConsoleCtrlHandler(&consoleHandler, FALSE), "SetConsoleCtrlHandler");
+            logDebug("signalhandler: removed console signal handler");
+        } catch (const std::system_error& e) {
+            logWarningWithException(e, "signalhandler: failed to remove console signal handler");
         }
     }
 

--- a/src/tremotesf/startup/windowsmessagehandler.h
+++ b/src/tremotesf/startup/windowsmessagehandler.h
@@ -5,10 +5,9 @@
 #ifndef TREMOTESF_WINDOWSMESSAGEHANDLER_H
 #define TREMOTESF_WINDOWSMESSAGEHANDLER_H
 
-#include <QtMessageHandler>
-
 namespace tremotesf {
-    void windowsMessageHandler(QtMsgType type, const QMessageLogContext& context, const QString& message);
+    void initWindowsMessageHandler();
+    void deinitWindowsMessageHandler();
 }
 
 #endif


### PR DESCRIPTION
When static object destructors are called, system may hold global lock, which may lead to deadlock if thread that is being joined tries to create another static object.

Instead we need to explicitly join threads before returning from main().