### PR TITLE
Separate torrents' error state from their download state (#252)

### DIFF
--- a/src/tremotesf/ui/screens/mainwindow/torrentsmodel.cpp
+++ b/src/tremotesf/ui/screens/mainwindow/torrentsmodel.cpp
@@ -75,17 +75,41 @@ namespace tremotesf {
             case Column::Status: {
                 switch (torrent->status()) {
                 case TorrentData::Status::Paused:
+                    if (torrent->hasError()) {
+                        return qApp->translate("tremotesf", "Paused (%1)", "Torrent status with error")
+                            .arg(torrent->errorString());
+                    }
                     return qApp->translate("tremotesf", "Paused", "Torrent status");
                 case TorrentData::Status::Downloading:
+                    if (torrent->hasError()) {
+                        return qApp->translate("tremotesf", "Downloading (%1)", "Torrent status with error")
+                            .arg(torrent->errorString());
+                    }
                     return qApp->translate("tremotesf", "Downloading", "Torrent status");
                 case TorrentData::Status::Seeding:
+                    if (torrent->hasError()) {
+                        return qApp->translate("tremotesf", "Seeding (%1)", "Torrent status with error")
+                            .arg(torrent->errorString());
+                    }
                     return qApp->translate("tremotesf", "Seeding", "Torrent status");
                 case TorrentData::Status::QueuedForDownloading:
                 case TorrentData::Status::QueuedForSeeding:
+                    if (torrent->hasError()) {
+                        return qApp->translate("tremotesf", "Queued (%1)", "Torrent status with error")
+                            .arg(torrent->errorString());
+                    }
                     return qApp->translate("tremotesf", "Queued", "Torrent status");
                 case TorrentData::Status::Checking:
+                    if (torrent->hasError()) {
+                        return qApp->translate("tremotesf", "Checking (%1)", "Torrent status with error")
+                            .arg(torrent->errorString());
+                    }
                     return qApp->translate("tremotesf", "Checking", "Torrent status");
                 case TorrentData::Status::QueuedForChecking:
+                    if (torrent->hasError()) {
+                        return qApp->translate("tremotesf", "Queued for checking (%1)", "Torrent status with error")
+                            .arg(torrent->errorString());
+                    }
                     return qApp->translate("tremotesf", "Queued for checking");
                 }
                 break;

--- a/src/tremotesf/ui/screens/mainwindow/torrentsproxymodel.cpp
+++ b/src/tremotesf/ui/screens/mainwindow/torrentsproxymodel.cpp
@@ -99,20 +99,27 @@ namespace tremotesf {
         using libtremotesf::TorrentData;
         switch (filter) {
         case Active:
-            return !torrent->hasError() &&
-                   ((torrent->status() == TorrentData::Status::Downloading && !torrent->isDownloadingStalled()) ||
-                    (torrent->status() == TorrentData::Status::Seeding && !torrent->isSeedingStalled()));
+            return (
+                (torrent->status() == TorrentData::Status::Downloading && !torrent->isDownloadingStalled()) ||
+                (torrent->status() == TorrentData::Status::Seeding && !torrent->isSeedingStalled())
+            );
         case Downloading:
-            return !torrent->hasError() && (torrent->status() == TorrentData::Status::Downloading ||
-                                            torrent->status() == TorrentData::Status::QueuedForDownloading);
+            return (
+                torrent->status() == TorrentData::Status::Downloading ||
+                torrent->status() == TorrentData::Status::QueuedForDownloading
+            );
         case Seeding:
-            return !torrent->hasError() && (torrent->status() == TorrentData::Status::Seeding ||
-                                            torrent->status() == TorrentData::Status::QueuedForSeeding);
+            return (
+                torrent->status() == TorrentData::Status::Seeding ||
+                torrent->status() == TorrentData::Status::QueuedForSeeding
+            );
         case Paused:
-            return !torrent->hasError() && torrent->status() == TorrentData::Status::Paused;
+            return torrent->status() == TorrentData::Status::Paused;
         case Checking:
-            return !torrent->hasError() && (torrent->status() == TorrentData::Status::Checking ||
-                                            torrent->status() == TorrentData::Status::QueuedForChecking);
+            return (
+                torrent->status() == TorrentData::Status::Checking ||
+                torrent->status() == TorrentData::Status::QueuedForChecking
+            );
         case Errored:
             return torrent->hasError();
         default:


### PR DESCRIPTION
This means that torrents that have error will be displayed with their download state (downloading/seeding/paused etc), and will appear in corresponding categpry filter (in addition to error filter).