### PR TITLE
Include CTest instead of using custom TREMOTESF_BUILD_TESTS option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
   while number of peers that we are currently downloading from / uploading to is displayed separately
 - Tracker's error is displayed in separate column
 - Torrents that have an error but are still being downloaded/uploaded are displayed under both "Status" filters simultaneously
+- TREMOTESF_BUILD_TESTS CMake option is replaced by standard BUILD_TESTING option
 
 ### Fixed
 - Fixed issues with lists or torrents/trackers not being updated sometimes

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,13 +11,8 @@ cmake_policy(VERSION ${CMAKE_MINIMUM_REQUIRED_VERSION}..3.25)
 
 project(tremotesf VERSION 2.0.0 LANGUAGES CXX)
 
-option(TREMOTESF_BUILD_TESTS "Build tests" ON)
-
+include(CTest)
 include(GNUInstallDirs)
-
-if (TREMOTESF_BUILD_TESTS)
-    enable_testing()
-endif()
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 


### PR DESCRIPTION
TREMOTESF_BUILD_TESTS is replaced by BUILD_TESTING.