### PR TITLE
Fix openssl RPM dependency

### DIFF
--- a/rpm/tremotesf.spec
+++ b/rpm/tremotesf.spec
@@ -36,7 +36,7 @@ BuildRequires: cmake(KF5WidgetsAddons)
 BuildRequires: cmake(KF5WindowSystem)
 BuildRequires: cmake(cxxopts)
 BuildRequires: pkgconfig(libpsl)
-BuildRequires: pkgconfig(openssl)
+BuildRequires: openssl-devel
 
 %if %{defined fedora}
 BuildRequires: cmake(httplib)


### PR DESCRIPTION
`pkgconfig(openssl)` may pull libressl on openSUSE. Since system libraries are always built with OpenSSL this may result in linking conflicts. Depend on openssl-devel explicitly.