### PR TITLE
Fix crash in MainWindowStatusBar (#300)

### DIFF
--- a/src/tremotesf/ui/screens/mainwindow/mainwindowstatusbar.cpp
+++ b/src/tremotesf/ui/screens/mainwindow/mainwindowstatusbar.cpp
@@ -20,9 +20,10 @@ namespace tremotesf {
     MainWindowStatusBar::MainWindowStatusBar(const Rpc* rpc, QWidget* parent) : QStatusBar(parent), mRpc(rpc) {
         setSizeGripEnabled(false);
 
-        delete layout();
+        auto container = new QWidget(this);
+        addPermanentWidget(container, 1);
 
-        auto layout = new QHBoxLayout(this);
+        auto layout = new QHBoxLayout(container);
         layout->setContentsMargins(8, 4, 8, 4);
 
         mNoServersErrorImage = new QLabel(this);


### PR DESCRIPTION
It's not safe to delete QStatusBar's layout since
it holds pointer to internally which may lead to double delete. Instead create container widget with our layout and add it using QStatusBar::addPermanentWidget().