### PR TITLE
Disable MSVC + Clang toolchain in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -192,7 +192,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        toolchain: ['msvc', 'msvc-clang']
+        toolchain:
+        - msvc
+        #- msvc-clang
 
     uses: ./.github/workflows/build-windows-msvc.yml
     with:


### PR DESCRIPTION
It seems that recent Windows runner update (probably MSVC update) introduced incompatibility between Qt headers and clang-cl. Just disable it for now.