### PR TITLE
Rework Qt translations deployment

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -183,7 +183,6 @@ target_compile_definitions(
     TREMOTESF_APP_ID="org.equeim.Tremotesf"
     TREMOTESF_APP_NAME="${TREMOTESF_APP_NAME}"
     TREMOTESF_VERSION="${PROJECT_VERSION}"
-    TREMOTESF_QT_TRANSLATIONS_FILENAME="${TREMOTESF_QT_TRANSLATIONS_FILENAME}"
 )
 if (registrable_domain_qt)
     target_compile_definitions(tremotesf_objects PUBLIC TREMOTESF_REGISTRABLE_DOMAIN_QT)

--- a/src/startup/main.cpp
+++ b/src/startup/main.cpp
@@ -114,7 +114,7 @@ int main(int argc, char** argv) {
 #else
             QLibraryInfo::location(QLibraryInfo::TranslationsPath);
 #endif
-        if (qtTranslator.load(QLocale(), TREMOTESF_QT_TRANSLATIONS_FILENAME ""_l1, "_"_l1, qtTranslationsPath)) {
+        if (qtTranslator.load(QLocale(), "qt"_l1, "_"_l1, qtTranslationsPath)) {
             qApp->installTranslator(&qtTranslator);
         } else {
             logWarning("Failed to load Qt translation for {} from {}", QLocale(), qtTranslationsPath);

--- a/translations/CMakeLists.txt
+++ b/translations/CMakeLists.txt
@@ -21,35 +21,24 @@ configure_file(translations.qrc "${CMAKE_BINARY_DIR}" COPYONLY)
 list(APPEND QRC_FILES "${CMAKE_BINARY_DIR}/translations.qrc")
 set(QRC_FILES ${QRC_FILES} PARENT_SCOPE)
 
-set(TREMOTESF_QT_TRANSLATIONS_FILENAME "qt")
-
 if (WIN32 OR APPLE)
-    set(TREMOTESF_BUNDLED_QT_TRANSLATIONS_DIR "translations")
+    message(STATUS "Building for Windows or macOS, deploying Qt translations")
+    set(TREMOTESF_BUNDLED_QT_TRANSLATIONS_DIR "qt-translations")
     set(TREMOTESF_BUNDLED_QT_TRANSLATIONS_DIR ${TREMOTESF_BUNDLED_QT_TRANSLATIONS_DIR} PARENT_SCOPE)
-
-    # When we are building with dynamic Qt, we can use windeployqt which will automatically
-    # merge all Qt translations in qt_*.qm and install with executable
-    # When we are building with static Qt, windeployqt does not work
-    # We then need to install translations ourselves, and since they are not merged
-    # we install only qtbase_*.qm
-
-    get_target_property(library_type Qt${TREMOTESF_QT_VERSION_MAJOR}::Core TYPE)
-    if (library_type STREQUAL "STATIC_LIBRARY")
-        message(STATUS "Building with static Qt, attempting to deploy Qt translations")
-        if (TREMOTESF_QT6)
-            set(relative_qt_translations_dir "translations/Qt6")
-        else()
-            set(relative_qt_translations_dir "share/qt5/translations")
-        endif()
-        find_file(qt_translations_dir "${relative_qt_translations_dir}" PATHS "${QT_HOST_PATH}")
-        if (qt_translations_dir)
-            message(STATUS "Deploying Qt translations from ${qt_translations_dir}")
-            set(TREMOTESF_QT_TRANSLATIONS_FILENAME "qtbase")
-            install(DIRECTORY "${qt_translations_dir}/" DESTINATION "${TREMOTESF_BUNDLED_QT_TRANSLATIONS_DIR}" FILES_MATCHING PATTERN "${TREMOTESF_QT_TRANSLATIONS_FILENAME}_*.qm")
-        else()
-            message(WARNING "Qt translations not found")
-        endif()
-    endif()
-endif()
-
-set(TREMOTESF_QT_TRANSLATIONS_FILENAME ${TREMOTESF_QT_TRANSLATIONS_FILENAME} PARENT_SCOPE)
+    if (DEFINED VCPKG_TARGET_TRIPLET)
+        # vcpkg
+        set(relative_qt_translations_dir "translations/Qt6")
+    else ()
+        # MSYS2
+        set(relative_qt_translations_dir "share/qt6/translations")
+    endif ()
+    if (DEFINED QT_HOST_PATH)
+        find_file(qt_translations_dir "${relative_qt_translations_dir}" PATHS "${QT_HOST_PATH}" REQUIRED)
+    else ()
+        find_file(qt_translations_dir "${relative_qt_translations_dir}" REQUIRED)
+    endif ()
+    message(STATUS "Deploying Qt translations from ${qt_translations_dir}")
+    install(DIRECTORY "${qt_translations_dir}/" DESTINATION "${TREMOTESF_BUNDLED_QT_TRANSLATIONS_DIR}"
+        FILES_MATCHING PATTERN "qt_*.qm" PATTERN "qtbase_*.qm" PATTERN "qtmultimedia_*.qm"
+        PATTERN "qt_help*" EXCLUDE)
+endif ()


### PR DESCRIPTION
For some languages qtbase translation files are empty and everything is located in main qt file. For others qt file is empty and depends on qtbase and qtmultimedia files. Just deploy all three and load qt file.

Also don't search Qt 5 path and add MSYS2 support.