### PR TITLE
Cache QIcon instances used in models (#522)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [Unreleased]
+### Fixed
+- Performance regression on Windows (and potential performance improvements on other platforms)
+
 ## [2.7.0] - 2024-08-31
 ### Added
 - Merging trackers when adding existing torrent

--- a/src/desktoputils.cpp
+++ b/src/desktoputils.cpp
@@ -9,14 +9,18 @@
 #include <QApplication>
 #include <QDesktopServices>
 #include <QDir>
+#include <QIcon>
 #include <QMessageBox>
 #include <QRegularExpression>
 #include <QStringBuilder>
+#include <QStyle>
 #include <QTextCursor>
 #include <QTextCharFormat>
 #include <QTextDocument>
 #include <QTextDocumentFragment>
 #include <QUrl>
+
+#include <fmt/format.h>
 
 #include "literals.h"
 #include "log/log.h"
@@ -24,29 +28,60 @@
 SPECIALIZE_FORMATTER_FOR_QDEBUG(QUrl)
 
 namespace tremotesf::desktoputils {
-    QString statusIconPath(StatusIcon icon) {
+    const QIcon& statusIcon(StatusIcon icon) {
         switch (icon) {
-        case ActiveIcon:
-            return ":/active.svg"_l1;
-        case CheckingIcon:
-            return ":/checking.svg"_l1;
-        case DownloadingIcon:
-            return ":/downloading.svg"_l1;
-        case ErroredIcon:
-            return ":/errored.svg"_l1;
-        case PausedIcon:
-            return ":/paused.svg"_l1;
-        case QueuedIcon:
-            return ":/queued.svg"_l1;
-        case SeedingIcon:
-            return ":/seeding.svg"_l1;
-        case StalledDownloadingIcon:
-            return ":/stalled-downloading.svg"_l1;
-        case StalledSeedingIcon:
-            return ":/stalled-seeding.svg"_l1;
+        case ActiveIcon: {
+            static const QIcon icon(":/active.svg"_l1);
+            return icon;
+        }
+        case CheckingIcon: {
+            static const QIcon icon(":/checking.svg"_l1);
+            return icon;
+        }
+        case DownloadingIcon: {
+            static const QIcon icon(":/downloading.svg"_l1);
+            return icon;
+        }
+        case ErroredIcon: {
+            static const QIcon icon(":/errored.svg"_l1);
+            return icon;
+        }
+        case PausedIcon: {
+            static const QIcon icon(":/paused.svg"_l1);
+            return icon;
+        }
+        case QueuedIcon: {
+            static const QIcon icon(":/queued.svg"_l1);
+            return icon;
+        }
+        case SeedingIcon: {
+            static const QIcon icon(":/seeding.svg"_l1);
+            return icon;
+        }
+        case StalledDownloadingIcon: {
+            static const QIcon icon(":/stalled-downloading.svg"_l1);
+            return icon;
         }
 
-        return {};
+        case StalledSeedingIcon: {
+            static QIcon icon(":/stalled-seeding.svg"_l1);
+            return icon;
+        }
+        }
+
+        throw std::logic_error(
+            fmt::format("Unknown StatusIcon value {}", static_cast<std::underlying_type_t<StatusIcon>>(icon))
+        );
+    }
+
+    const QIcon& standardFileIcon() {
+        static const auto icon = qApp->style()->standardIcon(QStyle::SP_FileIcon);
+        return icon;
+    }
+
+    const QIcon& standardDirIcon() {
+        static const auto icon = qApp->style()->standardIcon(QStyle::SP_DirIcon);
+        return icon;
     }
 
     void openFile(const QString& filePath, QWidget* parent) {

--- a/src/desktoputils.h
+++ b/src/desktoputils.h
@@ -5,8 +5,8 @@
 #ifndef TREMOTESF_DESKTOPUTILS_H
 #define TREMOTESF_DESKTOPUTILS_H
 
-#include <QString>
-
+class QIcon;
+class QString;
 class QTextDocument;
 class QWidget;
 
@@ -24,7 +24,10 @@ namespace tremotesf::desktoputils {
         StalledDownloadingIcon,
         StalledSeedingIcon
     };
-    QString statusIconPath(StatusIcon icon);
+    const QIcon& statusIcon(StatusIcon icon);
+
+    const QIcon& standardFileIcon();
+    const QIcon& standardDirIcon();
 
     void openFile(const QString& filePath, QWidget* parent = nullptr);
 

--- a/src/ui/itemmodels/basetorrentfilesmodel.cpp
+++ b/src/ui/itemmodels/basetorrentfilesmodel.cpp
@@ -7,6 +7,7 @@
 #include <QApplication>
 #include <QStyle>
 
+#include "desktoputils.h"
 #include "itemlistupdater.h"
 #include "formatutils.h"
 
@@ -38,9 +39,9 @@ namespace tremotesf {
         case Qt::DecorationRole:
             if (column == Column::Name) {
                 if (entry->isDirectory()) {
-                    return qApp->style()->standardIcon(QStyle::SP_DirIcon);
+                    return desktoputils::standardDirIcon();
                 }
-                return qApp->style()->standardIcon(QStyle::SP_FileIcon);
+                return desktoputils::standardFileIcon();
             }
             break;
         case Qt::DisplayRole:

--- a/src/ui/screens/mainwindow/alltrackersmodel.cpp
+++ b/src/ui/screens/mainwindow/alltrackersmodel.cpp
@@ -14,6 +14,7 @@
 #include "rpc/rpc.h"
 #include "ui/itemmodels/modelutils.h"
 #include "torrentsproxymodel.h"
+#include "desktoputils.h"
 
 namespace tremotesf {
     QVariant AllTrackersModel::data(const QModelIndex& index, int role) const {
@@ -24,11 +25,13 @@ namespace tremotesf {
         switch (role) {
         case TrackerRole:
             return item.tracker;
-        case Qt::DecorationRole:
+        case Qt::DecorationRole: {
             if (item.tracker.isEmpty()) {
-                return QApplication::style()->standardIcon(QStyle::SP_DirIcon);
+                return desktoputils::standardDirIcon();
             }
-            return QIcon::fromTheme("network-server"_l1);
+            static const auto networkServerIcon = QIcon::fromTheme("network-server"_l1);
+            return networkServerIcon;
+        }
         case Qt::DisplayRole:
         case Qt::ToolTipRole:
             if (item.tracker.isEmpty()) {

--- a/src/ui/screens/mainwindow/downloaddirectoriesmodel.cpp
+++ b/src/ui/screens/mainwindow/downloaddirectoriesmodel.cpp
@@ -17,6 +17,8 @@
 #include "ui/screens/mainwindow/downloaddirectoriesmodel.h"
 #include "torrentsproxymodel.h"
 
+#include "desktoputils.h"
+
 namespace tremotesf {
     QVariant DownloadDirectoriesModel::data(const QModelIndex& index, int role) const {
         if (!index.isValid()) {
@@ -26,8 +28,9 @@ namespace tremotesf {
         switch (role) {
         case DirectoryRole:
             return item.directory;
-        case Qt::DecorationRole:
-            return QApplication::style()->standardIcon(QStyle::SP_DirIcon);
+        case Qt::DecorationRole: {
+            return desktoputils::standardDirIcon();
+        }
         case Qt::DisplayRole:
         case Qt::ToolTipRole:
             if (item.directory.isEmpty()) {

--- a/src/ui/screens/mainwindow/statusfiltersmodel.cpp
+++ b/src/ui/screens/mainwindow/statusfiltersmodel.cpp
@@ -25,20 +25,21 @@ namespace tremotesf {
             return item.filter;
         case Qt::DecorationRole:
             switch (item.filter) {
-            case TorrentsProxyModel::All:
-                return QApplication::style()->standardIcon(QStyle::SP_DirIcon);
+            case TorrentsProxyModel::All: {
+                return desktoputils::standardDirIcon();
+            }
             case TorrentsProxyModel::Active:
-                return QIcon(desktoputils::statusIconPath(desktoputils::ActiveIcon));
+                return desktoputils::statusIcon(desktoputils::ActiveIcon);
             case TorrentsProxyModel::Downloading:
-                return QIcon(desktoputils::statusIconPath(desktoputils::DownloadingIcon));
+                return desktoputils::statusIcon(desktoputils::DownloadingIcon);
             case TorrentsProxyModel::Seeding:
-                return QIcon(desktoputils::statusIconPath(desktoputils::SeedingIcon));
+                return desktoputils::statusIcon(desktoputils::SeedingIcon);
             case TorrentsProxyModel::Paused:
-                return QIcon(desktoputils::statusIconPath(desktoputils::PausedIcon));
+                return desktoputils::statusIcon(desktoputils::PausedIcon);
             case TorrentsProxyModel::Checking:
-                return QIcon(desktoputils::statusIconPath(desktoputils::CheckingIcon));
+                return desktoputils::statusIcon(desktoputils::CheckingIcon);
             case TorrentsProxyModel::Errored:
-                return QIcon(desktoputils::statusIconPath(desktoputils::ErroredIcon));
+                return desktoputils::statusIcon(desktoputils::ErroredIcon);
             default:
                 break;
             }

--- a/src/ui/screens/mainwindow/torrentsmodel.cpp
+++ b/src/ui/screens/mainwindow/torrentsmodel.cpp
@@ -33,27 +33,27 @@ namespace tremotesf {
             if (static_cast<Column>(index.column()) == Column::Name) {
                 using namespace desktoputils;
                 if (torrent->data().error != TorrentData::Error::None) {
-                    return QIcon(statusIconPath(ErroredIcon));
+                    return statusIcon(ErroredIcon);
                 }
                 switch (torrent->data().status) {
                 case TorrentData::Status::Paused:
-                    return QIcon(statusIconPath(PausedIcon));
+                    return statusIcon(PausedIcon);
                 case TorrentData::Status::Seeding:
                     if (torrent->data().isSeedingStalled()) {
-                        return QIcon(statusIconPath(StalledSeedingIcon));
+                        return statusIcon(StalledSeedingIcon);
                     }
-                    return QIcon(statusIconPath(SeedingIcon));
+                    return statusIcon(SeedingIcon);
                 case TorrentData::Status::Downloading:
                     if (torrent->data().isDownloadingStalled()) {
-                        return QIcon(statusIconPath(StalledDownloadingIcon));
+                        return statusIcon(StalledDownloadingIcon);
                     }
-                    return QIcon(statusIconPath(DownloadingIcon));
+                    return statusIcon(DownloadingIcon);
                 case TorrentData::Status::QueuedForDownloading:
                 case TorrentData::Status::QueuedForSeeding:
-                    return QIcon(statusIconPath(QueuedIcon));
+                    return statusIcon(QueuedIcon);
                 case TorrentData::Status::Checking:
                 case TorrentData::Status::QueuedForChecking:
-                    return QIcon(statusIconPath(CheckingIcon));
+                    return statusIcon(CheckingIcon);
                 }
             }
             break;


### PR DESCRIPTION
Creating them can be expensive and models' data() functions are called frequently. Cache them in static variables.

Specifically, QStyle::standardIcon() became very slow in Qt 6.7 on Windows.