### PR TITLE
Workaround crash with GCC 12 (#539)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 ### Fixed
 - Black screen issues when closing fullscreen window on macOS
+- Crash with GCC 12
 
 ## [2.7.2] - 2024-09-15
 ### Fixed

--- a/src/ui/screens/torrentproperties/torrentfilesmodel.cpp
+++ b/src/ui/screens/torrentproperties/torrentfilesmodel.cpp
@@ -206,10 +206,10 @@ namespace tremotesf {
         mCreatingTree = true;
         beginResetModel();
 
-        auto self = QPointer(this);
-
-        auto [rootDirectory, files] =
-            co_await runOnThreadPool([files = std::vector(mTorrent->files())]() { return doCreateTree(files); });
+        auto [rootDirectory, files] = co_await runOnThreadPool(
+            [](const std::vector<TorrentFile>& files) { return doCreateTree(files); },
+            mTorrent->files()
+        );
 
         mRootDirectory = std::move(rootDirectory);
         endResetModel();


### PR DESCRIPTION
When co_await and lambda with captures are used in the same expression, GCC 12 bug causes double free. Use another runOnThreadPool overload that takes Args... which creates lambda outside of coroutine, so that this bug is not triggered.