### PR TITLE
Fix emitting dataChanged signal in TorrentsModel (#369)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Black screen issues when closing fullscreen window on macOS
 - File dialog being shown twice in some Linux environments
 - Crash with GCC 12
+- Torrent's details in list not being updated for most recently added torrent
 
 ## [2.7.2] - 2024-09-15
 ### Fixed

--- a/src/ui/screens/mainwindow/torrentsmodel.cpp
+++ b/src/ui/screens/mainwindow/torrentsmodel.cpp
@@ -376,7 +376,7 @@ namespace tremotesf {
                 QObject::connect(rpc, &Rpc::onChangedTorrents, this, [=, this](size_t first, size_t last) {
                     emit dataChanged(
                         index(static_cast<int>(first), 0),
-                        index(static_cast<int>(last), columnCount() - 1)
+                        index(static_cast<int>(last - 1), columnCount() - 1)
                     );
                 });
 


### PR DESCRIPTION
last in Rpc::onChangedTorrents actually means after-the-last.