### PR TITLE
Use QT_DEBUG macro instead of NDEBUG

### DIFF
--- a/src/log/log.cpp
+++ b/src/log/log.cpp
@@ -13,10 +13,10 @@
 
 namespace tremotesf {
     constexpr auto defaultLogLevel =
-#ifdef NDEBUG
-        QtInfoMsg;
-#else
+#ifdef QT_DEBUG
         QtDebugMsg;
+#else
+        QtInfoMsg;
 #endif
 
     Q_LOGGING_CATEGORY(tremotesfLoggingCategory, tremotesfLoggingCategoryName, defaultLogLevel)

--- a/src/startup/windowsmessagehandler.cpp
+++ b/src/startup/windowsmessagehandler.cpp
@@ -202,10 +202,10 @@ namespace tremotesf {
 
         void callReleaseOrDebugHandler(QtMsgType type, const QMessageLogContext& context, const QString& message) {
             const QString formatted = qFormatLogMessage(type, context, message);
-#ifdef NDEBUG
-            releaseMessageHandler(formatted);
-#else
+#ifdef QT_DEBUG
             debugMessageHandler(formatted);
+#else
+            releaseMessageHandler(formatted);
 #endif
         }
 
@@ -225,14 +225,14 @@ namespace tremotesf {
         qSetMessagePattern(
             "[%{time yyyy.MM.dd h:mm:ss.zzz t} %{if-debug}D%{endif}%{if-info}I%{endif}%{if-warning}W%{endif}%{if-critical}C%{endif}%{if-fatal}F%{endif}] %{message}"_l1
         );
-#ifdef NDEBUG
+#ifndef QT_DEBUG
         globalFileLogger = std::make_unique<FileLogger>();
         debug().log("FileLogger: created, starting write thread");
 #endif
     }
 
     void deinitWindowsMessageHandler() {
-#ifdef NDEBUG
+#ifndef QT_DEBUG
         if (globalFileLogger) {
             globalFileLogger->finishWriting();
         }


### PR DESCRIPTION
NDEBUG is not guaranteed to be set in release builds, e.g. with None configuration and custom build flags like Linux distros do. Instead use QT_DEBUG which is set explicitly only when configuration is Debug.