### PR TITLE
Simplify formatRelativeDateTime and fix handling of today's date

### DIFF
--- a/src/formatutils.cpp
+++ b/src/formatutils.cpp
@@ -242,14 +242,7 @@ namespace tremotesf::formatutils {
                     return qApp->translate("tremotesf", "%n minute(s) ago", nullptr, minutesToNow);
                 }
             }
-            const qint64 daysToNow = dateTime.daysTo(now);
-            QString dateString;
-            if (daysToNow < 2 && daysToNow > 0) {
-                dateString = formatRelativeDate(dateTime.date(), format, locale);
-            } else {
-                dateString = locale.toString(dateTime.date(), format);
-            }
-            return addTimeToDate(dateString, dateTime.time(), format, locale);
+            return addTimeToDate(formatRelativeDate(dateTime.date(), format, locale), dateTime.time(), format, locale);
         }
     }
 


### PR DESCRIPTION
Remove handling of daysTo since it's redundant - formatRelativeDate already does that. This also fixes handling of today's date which was incorrectly rejected (daysTo == 0).