### PR TITLE
Call shouldExitBecauseAnotherInstanceIsRunning() after QApplication i…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [Unreleased]
+### Fixed
+- Not working file dialogs when installed through Flatpak
+
 ## [2.8.0] - 2025-04-09
 ### Added
 - Option to show torrent properties in a panel in the main window instead of dialog


### PR DESCRIPTION
…nitialization (#624)

It uses IpcClient which it turn uses Qt D-Bus, which may malfunction if used before QApplication is created. This can cause D-Bus-related functionality to stop working (e.g. portal-based QFileDialog).