### PR TITLE
Use QHeaderView::setFirstSectionMovable() on TorrentsView

### DIFF
--- a/src/ui/screens/mainwindow/torrentsview.cpp
+++ b/src/ui/screens/mainwindow/torrentsview.cpp
@@ -30,6 +30,7 @@ namespace tremotesf {
         setRootIsDecorated(false);
 
         const auto header = this->header();
+        header->setFirstSectionMovable(true);
         if (!header->restoreState(Settings::instance()->get_torrentsViewHeaderState())) {
             using C = TorrentsModel::Column;
             const std::set defaultColumns{
@@ -61,7 +62,6 @@ namespace tremotesf {
                 header->visualIndex(static_cast<int>(C::AddedDate)) + 1
             );
             sortByColumn(static_cast<int>(TorrentsModel::Column::AddedDate), Qt::DescendingOrder);
-            header->setFirstSectionMovable(true);
         }
     }
 

--- a/src/ui/screens/mainwindow/torrentsview.cpp
+++ b/src/ui/screens/mainwindow/torrentsview.cpp
@@ -61,6 +61,7 @@ namespace tremotesf {
                 header->visualIndex(static_cast<int>(C::AddedDate)) + 1
             );
             sortByColumn(static_cast<int>(TorrentsModel::Column::AddedDate), Qt::DescendingOrder);
+            header->setFirstSectionMovable(true);
         }
     }
 

--- a/src/ui/widgets/basetreeview.cpp
+++ b/src/ui/widgets/basetreeview.cpp
@@ -15,6 +15,7 @@ namespace tremotesf {
         setUniformRowHeights(true);
 
         header()->setContextMenuPolicy(Qt::CustomContextMenu);
+        header()->setFirstSectionMovable(true);
 
         QObject::connect(header(), &QHeaderView::customContextMenuRequested, this, [=, this](QPoint pos) {
             if (!model()) {

--- a/src/ui/widgets/basetreeview.cpp
+++ b/src/ui/widgets/basetreeview.cpp
@@ -15,7 +15,6 @@ namespace tremotesf {
         setUniformRowHeights(true);
 
         header()->setContextMenuPolicy(Qt::CustomContextMenu);
-        header()->setFirstSectionMovable(true);
 
         QObject::connect(header(), &QHeaderView::customContextMenuRequested, this, [=, this](QPoint pos) {
             if (!model()) {


### PR DESCRIPTION
### Description
Columns of torrent list enabled to be movable by default.
But first column "Name" was not movable by nature of QTreeView, not by intention.
https://doc.qt.io/qt-6/qheaderview.html#firstSectionMovable-prop

### Expected behavior
Name column just be movable like other columns.

### Actual behavior
Only Name column is not movable.

### Changes Made
Use QHeaderView::setFirstSectionMovable() to enable first column movable.