### PR TITLE
Replace BaseTreeView class with setCommonTreeViewProperties function

### DIFF
--- a/src/ui/screens/mainwindow/torrentsview.cpp
+++ b/src/ui/screens/mainwindow/torrentsview.cpp
@@ -7,6 +7,7 @@
 #include <set>
 #include <QHeaderView>
 
+#include "ui/widgets/basetreeview.h"
 #include "ui/widgets/progressbardelegate.h"
 #include "downloaddirectorydelegate.h"
 #include "settings.h"
@@ -14,7 +15,8 @@
 #include "torrentsproxymodel.h"
 
 namespace tremotesf {
-    TorrentsView::TorrentsView(TorrentsProxyModel* model, QWidget* parent) : BaseTreeView(parent) {
+    TorrentsView::TorrentsView(TorrentsProxyModel* model, QWidget* parent) : QTreeView(parent) {
+        setCommonTreeViewProperties(this, true);
         setContextMenuPolicy(Qt::CustomContextMenu);
         setItemDelegate(new TooltipWhenElidedDelegate(this));
         setItemDelegateForColumn(
@@ -27,10 +29,8 @@ namespace tremotesf {
         );
         setModel(model);
         setSelectionMode(QAbstractItemView::ExtendedSelection);
-        setRootIsDecorated(false);
 
         const auto header = this->header();
-        header->setFirstSectionMovable(true);
         if (!header->restoreState(Settings::instance()->get_torrentsViewHeaderState())) {
             using C = TorrentsModel::Column;
             const std::set defaultColumns{

--- a/src/ui/screens/mainwindow/torrentsview.h
+++ b/src/ui/screens/mainwindow/torrentsview.h
@@ -5,12 +5,12 @@
 #ifndef TREMOTESF_TORRENTSVIEW_H
 #define TREMOTESF_TORRENTSVIEW_H
 
-#include "ui/widgets/basetreeview.h"
+#include <QTreeView>
 
 namespace tremotesf {
     class TorrentsProxyModel;
 
-    class TorrentsView final : public BaseTreeView {
+    class TorrentsView final : public QTreeView {
         Q_OBJECT
     public:
         TorrentsView(TorrentsProxyModel* model, QWidget* parent = nullptr);

--- a/src/ui/screens/torrentproperties/torrentpropertieswidget.cpp
+++ b/src/ui/screens/torrentproperties/torrentpropertieswidget.cpp
@@ -41,6 +41,7 @@
 #include "ui/itemmodels/baseproxymodel.h"
 #include "ui/itemmodels/stringlistmodel.h"
 #include "ui/stylehelpers.h"
+#include "ui/widgets/basetreeview.h"
 #include "ui/widgets/progressbardelegate.h"
 #include "ui/widgets/tooltipwhenelideddelegate.h"
 #include "ui/widgets/torrentfilesview.h"
@@ -288,14 +289,14 @@ namespace tremotesf {
         auto peersTab = new QWidget(this);
         auto peersTabLayout = new QVBoxLayout(peersTab);
 
-        mPeersView = new BaseTreeView(this);
+        mPeersView = new QTreeView(this);
+        setCommonTreeViewProperties(mPeersView, true);
         mPeersView->setItemDelegate(new TooltipWhenElidedDelegate(this));
         mPeersView->setItemDelegateForColumn(
             static_cast<int>(PeersModel::Column::ProgressBar),
             new ProgressBarDelegate(PeersModel::SortRole, this)
         );
         mPeersView->setModel(peersProxyModel);
-        mPeersView->setRootIsDecorated(false);
         mPeersView->header()->restoreState(Settings::instance()->get_peersViewHeaderState());
         overrideBreezeFramelessScrollAreaHeuristic(mPeersView, true);
 
@@ -312,10 +313,10 @@ namespace tremotesf {
         auto webSeedersTab = new QWidget(this);
         auto webSeedersTabLayout = new QVBoxLayout(webSeedersTab);
 
-        auto webSeedersView = new BaseTreeView(this);
+        auto webSeedersView = new QTreeView(this);
+        setCommonTreeViewProperties(webSeedersView, true);
         webSeedersView->header()->setContextMenuPolicy(Qt::DefaultContextMenu);
         webSeedersView->setModel(webSeedersProxyModel);
-        webSeedersView->setRootIsDecorated(false);
         overrideBreezeFramelessScrollAreaHeuristic(webSeedersView, true);
 
         webSeedersTabLayout->addWidget(webSeedersView);

--- a/src/ui/screens/torrentproperties/torrentpropertieswidget.h
+++ b/src/ui/screens/torrentproperties/torrentpropertieswidget.h
@@ -9,8 +9,9 @@
 
 #include <QTabWidget>
 
+class QTreeView;
+
 namespace tremotesf {
-    class BaseTreeView;
     class PeersModel;
     class Rpc;
     class StringListModel;
@@ -43,7 +44,7 @@ namespace tremotesf {
         TorrentFilesModel* mFilesModel{};
         TorrentFilesView* mFilesView{};
         TrackersViewWidget* mTrackersViewWidget{};
-        BaseTreeView* mPeersView{};
+        QTreeView* mPeersView{};
         PeersModel* mPeersModel{};
         StringListModel* mWebSeedersModel{};
 

--- a/src/ui/screens/torrentproperties/trackersviewwidget.cpp
+++ b/src/ui/screens/torrentproperties/trackersviewwidget.cpp
@@ -16,6 +16,7 @@
 #include <QMenu>
 #include <QMessageBox>
 #include <QPushButton>
+#include <QTreeView>
 #include <QVBoxLayout>
 
 #include "rpc/torrent.h"
@@ -31,15 +32,15 @@ using namespace Qt::StringLiterals;
 
 namespace tremotesf {
     namespace {
-        class EnterEatingTreeView final : public BaseTreeView {
+        class EnterEatingTreeView final : public QTreeView {
             Q_OBJECT
 
         public:
-            explicit EnterEatingTreeView(QWidget* parent = nullptr) : BaseTreeView(parent) {}
+            explicit EnterEatingTreeView(QWidget* parent = nullptr) : QTreeView(parent) {}
 
         protected:
             void keyPressEvent(QKeyEvent* event) override {
-                BaseTreeView::keyPressEvent(event);
+                QTreeView::keyPressEvent(event);
                 switch (event->key()) {
                 case Qt::Key_Enter:
                 case Qt::Key_Return:
@@ -61,10 +62,10 @@ namespace tremotesf {
           mTrackersView(new EnterEatingTreeView(this)) {
         auto layout = new QHBoxLayout(this);
 
+        setCommonTreeViewProperties(mTrackersView, true);
         mTrackersView->setContextMenuPolicy(Qt::CustomContextMenu);
         mTrackersView->setModel(mProxyModel);
         mTrackersView->setSelectionMode(QAbstractItemView::ExtendedSelection);
-        mTrackersView->setRootIsDecorated(false);
         mTrackersView->header()->restoreState(Settings::instance()->get_trackersViewHeaderState());
         QObject::connect(mTrackersView, &EnterEatingTreeView::activated, this, &TrackersViewWidget::showEditDialogs);
 

--- a/src/ui/screens/torrentproperties/trackersviewwidget.h
+++ b/src/ui/screens/torrentproperties/trackersviewwidget.h
@@ -7,13 +7,14 @@
 
 #include <QWidget>
 
+class QTreeView;
+
 namespace tremotesf {
     class Torrent;
 }
 
 namespace tremotesf {
     class BaseProxyModel;
-    class BaseTreeView;
     class Rpc;
     class TrackersModel;
 
@@ -36,7 +37,7 @@ namespace tremotesf {
         Rpc* mRpc{};
         TrackersModel* mModel{};
         BaseProxyModel* mProxyModel{};
-        BaseTreeView* mTrackersView{};
+        QTreeView* mTrackersView{};
     };
 }
 

--- a/src/ui/widgets/basetreeview.cpp
+++ b/src/ui/widgets/basetreeview.cpp
@@ -7,36 +7,47 @@
 #include <QAbstractItemModel>
 #include <QHeaderView>
 #include <QMenu>
+#include <QTreeView>
 
 namespace tremotesf {
-    BaseTreeView::BaseTreeView(QWidget* parent) : QTreeView(parent) {
-        setAllColumnsShowFocus(true);
-        setSortingEnabled(true);
-        setUniformRowHeights(true);
+    void setCommonTreeViewProperties(QTreeView* view, bool isFlatList) {
+        view->setAllColumnsShowFocus(true);
+        view->setSortingEnabled(true);
+        view->setUniformRowHeights(true);
+        if (isFlatList) {
+            view->setRootIsDecorated(false);
+            view->header()->setFirstSectionMovable(true);
+        }
 
-        header()->setContextMenuPolicy(Qt::CustomContextMenu);
+        const auto header = view->header();
+        header->setContextMenuPolicy(Qt::CustomContextMenu);
 
-        QObject::connect(header(), &QHeaderView::customContextMenuRequested, this, [=, this](QPoint pos) {
-            if (!model()) {
+        QObject::connect(header, &QHeaderView::customContextMenuRequested, view, [=](QPoint pos) {
+            const auto model = view->model();
+            if (!model) {
                 return;
             }
 
-            QMenu contextMenu;
-            for (int i = 0, max = model()->columnCount(); i < max; ++i) {
-                QAction* action = contextMenu.addAction(model()->headerData(i, Qt::Horizontal).toString());
+            const auto menu = new QMenu(view);
+            menu->setAttribute(Qt::WA_DeleteOnClose);
+
+            for (int i = 0, max = model->columnCount(); i < max; ++i) {
+                const auto action = menu->addAction(model->headerData(i, Qt::Horizontal).toString());
                 action->setCheckable(true);
-                action->setChecked(!isColumnHidden(i));
+                action->setChecked(!view->isColumnHidden(i));
             }
 
-            QAction* action = contextMenu.exec(header()->viewport()->mapToGlobal(pos));
-            if (action) {
-                const auto column = static_cast<int>(contextMenu.actions().indexOf(action));
-                if (isColumnHidden(column)) {
-                    showColumn(column);
+            QObject::connect(menu, &QMenu::triggered, view, [=](QAction* action) {
+                const auto column = static_cast<int>(menu->actions().indexOf(action));
+                if (view->isColumnHidden(column)) {
+                    view->showColumn(column);
                 } else {
-                    hideColumn(column);
+                    view->hideColumn(column);
                 }
-            }
+            });
+
+            menu->popup(header->viewport()->mapToGlobal(pos));
         });
     }
+
 }

--- a/src/ui/widgets/basetreeview.h
+++ b/src/ui/widgets/basetreeview.h
@@ -5,15 +5,10 @@
 #ifndef TREMOTESF_BASETREEVIEW_H
 #define TREMOTESF_BASETREEVIEW_H
 
-#include <QTreeView>
+class QTreeView;
 
 namespace tremotesf {
-    class BaseTreeView : public QTreeView {
-        Q_OBJECT
-
-    public:
-        explicit BaseTreeView(QWidget* parent = nullptr);
-    };
+    void setCommonTreeViewProperties(QTreeView* view, bool isFlatList);
 }
 
 #endif // TREMOTESF_BASETREEVIEW_H

--- a/src/ui/widgets/torrentfilesview.cpp
+++ b/src/ui/widgets/torrentfilesview.cpp
@@ -14,6 +14,7 @@
 #include "rpc/mounteddirectoriesutils.h"
 #include "rpc/serversettings.h"
 
+#include "basetreeview.h"
 #include "desktoputils.h"
 #include "filemanagerlauncher.h"
 #include "settings.h"
@@ -31,7 +32,7 @@ using namespace Qt::StringLiterals;
 
 namespace tremotesf {
     TorrentFilesView::TorrentFilesView(LocalTorrentFilesModel* model, Rpc* rpc, QWidget* parent)
-        : BaseTreeView(parent),
+        : QTreeView(parent),
           mLocalFile(true),
           mModel(model),
           mProxyModel(new TorrentFilesProxyModel(
@@ -46,7 +47,7 @@ namespace tremotesf {
     }
 
     TorrentFilesView::TorrentFilesView(TorrentFilesModel* model, Rpc* rpc, QWidget* parent)
-        : BaseTreeView(parent),
+        : QTreeView(parent),
           mLocalFile(false),
           mModel(model),
           mProxyModel(new TorrentFilesProxyModel(
@@ -101,6 +102,7 @@ namespace tremotesf {
     }
 
     void TorrentFilesView::init() {
+        setCommonTreeViewProperties(this, false);
         setContextMenuPolicy(Qt::CustomContextMenu);
         setModel(mProxyModel);
         setSelectionMode(QAbstractItemView::ExtendedSelection);

--- a/src/ui/widgets/torrentfilesview.h
+++ b/src/ui/widgets/torrentfilesview.h
@@ -7,7 +7,7 @@
 
 #include <functional>
 
-#include "basetreeview.h"
+#include <QTreeView>
 
 namespace tremotesf {
     class BaseTorrentFilesModel;
@@ -16,7 +16,7 @@ namespace tremotesf {
     class TorrentFilesModel;
     class TorrentFilesProxyModel;
 
-    class TorrentFilesView final : public BaseTreeView {
+    class TorrentFilesView final : public QTreeView {
         Q_OBJECT
 
     public:


### PR DESCRIPTION
We don't override anything so there is no need to make it a class.

Also use QMenu::popup instead of QMenu::exec to avoid nested event loop.