### PR TITLE
Fix opening a single file in a direcory

### DIFF
--- a/src/ui/screens/torrentproperties/torrentfilesmodel.cpp
+++ b/src/ui/screens/torrentproperties/torrentfilesmodel.cpp
@@ -172,9 +172,6 @@ namespace tremotesf {
         if (!index.isValid()) {
             return localTorrentDownloadDirectoryPath(mRpc, mTorrent);
         }
-        if (mTorrent->data().singleFile) {
-            return localTorrentRootFilePath(mRpc, mTorrent);
-        }
         const auto* entry = static_cast<const TorrentFilesModelEntry*>(index.internalPointer());
         QString path(entry->path());
         if (!entry->isDirectory() && entry->progress() < 1 && mRpc->serverSettings()->data().renameIncompleteFiles) {


### PR DESCRIPTION
# How to reproduce
1. Rpc return fileCount=1 even when there is a single file in a directory
2. Double clicking the file on files list

# Expected result
Opening the file

# Actual result
Opens containing directory instead

# Changes made
* After delete `singleFile` condition all sort of action works as intended

# Case tested
* Open and open directory on torrents list
* Open and open directory on files list for single file, single file in directory and multiple files in directory
