### PR TITLE
Add priority icons to torrents view

### DIFF
--- a/data/icons/status/priority-high.svg
+++ b/data/icons/status/priority-high.svg
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg version="1.1" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
+ <g>
+  <circle cx="8" cy="8" r="5.4545" fill="#f00" stroke="#c00" stroke-width="1.0909"/>
+ </g>
+</svg>

--- a/data/icons/status/priority-low.svg
+++ b/data/icons/status/priority-low.svg
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg version="1.1" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
+ <g>
+  <circle cx="8" cy="8" r="5.4545" fill="#ff0" stroke="#cc0" stroke-width="1.0909"/>
+ </g>
+</svg>

--- a/data/icons/status/priority-normal.svg
+++ b/data/icons/status/priority-normal.svg
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg version="1.1" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
+ <g>
+  <circle cx="8" cy="8" r="5.4545" fill="#0f0" stroke="#0c0" stroke-width="1.0909"/>
+ </g>
+</svg>

--- a/data/icons/status/status.qrc
+++ b/data/icons/status/status.qrc
@@ -11,6 +11,9 @@ SPDX-License-Identifier: CC0-1.0
         <file>downloading.svg</file>
         <file>errored.svg</file>
         <file>paused.svg</file>
+        <file>priority-high.svg</file>
+        <file>priority-low.svg</file>
+        <file>priority-normal.svg</file>
         <file>queued.svg</file>
         <file>seeding.svg</file>
         <file>stalled-downloading.svg</file>

--- a/src/desktoputils.cpp
+++ b/src/desktoputils.cpp
@@ -73,6 +73,24 @@ namespace tremotesf::desktoputils {
         throw std::logic_error(fmt::format("Unknown StatusIcon value {}", std::to_underlying(icon)));
     }
 
+    const QIcon& priorityIcon(PriorityIcon icon) {
+        switch (icon) {
+        case HighPriorityIcon: {
+            static const QIcon qicon(":/priority-high.svg"_L1);
+            return qicon;
+        }
+        case NormalPriorityIcon: {
+            static const QIcon qicon(":/priority-normal.svg"_L1);
+            return qicon;
+        }
+        case LowPriorityIcon: {
+            static const QIcon qicon(":/priority-low.svg"_L1);
+            return qicon;
+        }
+        }
+        throw std::logic_error(fmt::format("Unknown PriorityIcon value {}", static_cast<int>(icon)));
+    }
+
     const QIcon& standardFileIcon() {
         static const auto icon = qApp->style()->standardIcon(QStyle::SP_FileIcon);
         return icon;

--- a/src/desktoputils.h
+++ b/src/desktoputils.h
@@ -26,6 +26,9 @@ namespace tremotesf::desktoputils {
     };
     const QIcon& statusIcon(StatusIcon icon);
 
+    enum PriorityIcon { HighPriorityIcon, NormalPriorityIcon, LowPriorityIcon };
+    const QIcon& priorityIcon(PriorityIcon icon);
+
     const QIcon& standardFileIcon();
     const QIcon& standardDirIcon();
 

--- a/src/ui/screens/mainwindow/torrentsmodel.cpp
+++ b/src/ui/screens/mainwindow/torrentsmodel.cpp
@@ -68,6 +68,16 @@ namespace tremotesf {
                 case TorrentData::Status::QueuedForChecking:
                     return statusIcon(CheckingIcon);
                 }
+            } else if (static_cast<Column>(index.column()) == Column::Priority) {
+                using namespace desktoputils;
+                switch (torrent->data().bandwidthPriority) {
+                case TorrentData::Priority::High:
+                    return priorityIcon(HighPriorityIcon);
+                case TorrentData::Priority::Normal:
+                    return priorityIcon(NormalPriorityIcon);
+                case TorrentData::Priority::Low:
+                    return priorityIcon(LowPriorityIcon);
+                }
             }
             break;
         case Qt::DisplayRole:


### PR DESCRIPTION
# Description
I used transgui that shows priority with color icons helping rapid eye scanning.
So here I present same functionality to tremotesf.

# Changes made
- Add priorityIcon() for decorating priority column, just like statusIcon() for name column.
- Add 3 svg icons. Copied queued.svg and only circle remains with color changes.
- status.qrc file modified but I don't know what this file is for.