### PR TITLE
Add keyboard shortcut to rename torrents

### DIFF
--- a/src/ui/screens/mainwindow/mainwindow.cpp
+++ b/src/ui/screens/mainwindow/mainwindow.cpp
@@ -642,6 +642,7 @@ namespace tremotesf {
                 //: Torrent's context menu item
                 qApp->translate("tremotesf", "&Rename")
             );
+            mRenameTorrentAction->setShortcuts(QKeySequence::listFromString("F2"));
             QObject::connect(mRenameTorrentAction, &QAction::triggered, this, [this] {
                 const auto indexes = mTorrentsView.selectionModel()->selectedRows();
                 if (indexes.size() == 1) {

--- a/src/ui/screens/mainwindow/mainwindow.cpp
+++ b/src/ui/screens/mainwindow/mainwindow.cpp
@@ -642,7 +642,7 @@ namespace tremotesf {
                 //: Torrent's context menu item
                 qApp->translate("tremotesf", "&Rename")
             );
-            mRenameTorrentAction->setShortcuts(QKeySequence::listFromString("F2"));
+            mRenameTorrentAction->setShortcut(Qt::Key_F2);
             QObject::connect(mRenameTorrentAction, &QAction::triggered, this, [this] {
                 const auto indexes = mTorrentsView.selectionModel()->selectedRows();
                 if (indexes.size() == 1) {


### PR DESCRIPTION
Fix #121, add F2 shortcut to Rename menu action on torrents list.