### PR TITLE
Remove checkSingleFile request and instead just check the existence o…

### DIFF
--- a/src/rpc/rpc.h
+++ b/src/rpc/rpc.h
@@ -214,7 +214,6 @@ namespace tremotesf {
 
         Coroutine<> getServerSettings();
         Coroutine<> getTorrents();
-        Coroutine<> checkTorrentsSingleFile(std::vector<int> torrentIds);
         Coroutine<> getServerStats();
 
         Coroutine<> connectAndPerformDataUpdates();

--- a/src/rpc/serversettings.cpp
+++ b/src/rpc/serversettings.cpp
@@ -105,8 +105,6 @@ namespace tremotesf {
 
     bool ServerSettingsData::hasTrackerListProperty() const { return (rpcVersion >= 17); }
 
-    bool ServerSettingsData::hasFileCountProperty() const { return (rpcVersion >= 17); }
-
     bool ServerSettingsData::hasLabelsProperty() const { return (rpcVersion >= 16); }
 
     ServerSettings::ServerSettings(Rpc* rpc, QObject* parent) : QObject(parent), mRpc(rpc), mSaveOnSet(true) {}

--- a/src/rpc/serversettings.h
+++ b/src/rpc/serversettings.h
@@ -40,7 +40,6 @@ namespace tremotesf {
         [[nodiscard]] bool hasSessionIdFile() const;
         [[nodiscard]] bool hasTableMode() const;
         [[nodiscard]] bool hasTrackerListProperty() const;
-        [[nodiscard]] bool hasFileCountProperty() const;
         [[nodiscard]] bool hasLabelsProperty() const;
 
         int rpcVersion = 0;

--- a/src/rpc/torrent.cpp
+++ b/src/rpc/torrent.cpp
@@ -73,7 +73,6 @@ namespace tremotesf {
         CreationDate,
         Comment,
         TrackerStats,
-        FileCount,
         Labels,
 
         Count
@@ -174,8 +173,6 @@ namespace tremotesf {
                 return "comment"_L1;
             case TorrentData::UpdateKey::TrackerStats:
                 return "trackerStats"_L1;
-            case TorrentData::UpdateKey::FileCount:
-                return "file-count"_L1;
             case TorrentData::UpdateKey::Labels:
                 return "labels"_L1;
             case TorrentData::UpdateKey::Count:
@@ -200,7 +197,6 @@ namespace tremotesf {
             return static_cast<TorrentData::UpdateKey>(foundKey->second);
         }
 
-        constexpr auto prioritiesKey = "priorities"_L1;
         constexpr auto wantedFilesKey = "files-wanted"_L1;
         constexpr auto unwantedFilesKey = "files-unwanted"_L1;
 
@@ -466,9 +462,6 @@ namespace tremotesf {
             setChanged(totalLeechersFromTrackersCount, newTotalLeechers, changed);
             return;
         }
-        case TorrentData::UpdateKey::FileCount:
-            setChanged(singleFile, value.toInt() == 1, changed);
-            return;
         case TorrentData::UpdateKey::Labels: {
             setChanged(
                 labels,
@@ -523,9 +516,6 @@ namespace tremotesf {
     QJsonArray Torrent::updateFields(const ServerSettings* serverSettings) {
         QJsonArray fields{};
         for (auto key : allUpdateKeys) {
-            if (key == TorrentData::UpdateKey::FileCount && !serverSettings->data().hasFileCountProperty()) {
-                continue;
-            }
             if (key == TorrentData::UpdateKey::Labels && !serverSettings->data().hasLabelsProperty()) {
                 continue;
             }
@@ -899,10 +889,6 @@ namespace tremotesf {
         updater.update(mPeers, std::move(newPeers));
 
         emit peersUpdated(updater.removedIndexRanges, updater.changedIndexRanges, updater.addedCount);
-    }
-
-    void Torrent::checkSingleFile(const QJsonObject& torrentMap) {
-        mData.singleFile = (torrentMap.value(prioritiesKey).toArray().size() == 1);
     }
 }
 

--- a/src/rpc/torrent.h
+++ b/src/rpc/torrent.h
@@ -120,8 +120,6 @@ namespace tremotesf {
 
         std::vector<QString> labels{};
 
-        bool singleFile = true;
-
         std::vector<Tracker> trackers{};
 
         [[nodiscard]] bool hasError() const { return error != Error::None; }
@@ -195,8 +193,6 @@ namespace tremotesf {
         update(std::span<const std::optional<TorrentData::UpdateKey>> keys, const QJsonArray& values);
         void updateFiles(const QJsonObject& torrentMap);
         void updatePeers(const QJsonObject& torrentMap);
-
-        void checkSingleFile(const QJsonObject& torrentMap);
 
     private:
         Rpc* mRpc{};


### PR DESCRIPTION
…f incomplete file

This request was needed to know whether the torrent is single file or a directory with many files. The reason why we needed to know this is because renaming of incomplete files works only on files, not directories, so when user clicks on "Open" menu item, we need to add .part to the path only if the torrent is a file. However this approach was flawed: it incorrectly handled the case of a torrent with a single file inside directory.

Instead we can simply check if a file with .part suffix exists, and open it only in that case.