### PR TITLE
Set a larger default minimum size for text input dialogs

### DIFF
--- a/src/ui/widgets/textinputdialog.cpp
+++ b/src/ui/widgets/textinputdialog.cpp
@@ -67,7 +67,7 @@ namespace tremotesf {
 
         layout->addWidget(dialogButtonBox);
 
-        resize(sizeHint().expandedTo(QSize(256, 0)));
+        resize(sizeHint().expandedTo(QSize(720, 0)));
     }
 
     QString TextInputDialog::text() const { return mLineEdit ? mLineEdit->text() : mPlainTextEdit->toPlainText(); }


### PR DESCRIPTION
# Description
When updating trackers or renaming files, the text input dialog is very small and almost always has to be resized to see all the text on Fedora. This updates the default width to something more usable.

# Changes made
- Update default minimum width for text input dialogs from 256px to 720px.

