### PR TITLE
Fixed cursor

### DIFF
--- a/src/ui/widgets/remotedirectoryselectionwidget.cpp
+++ b/src/ui/widgets/remotedirectoryselectionwidget.cpp
@@ -113,7 +113,11 @@ namespace tremotesf {
         }
 
         const auto lineEdit = lineEditFromTextField();
-        const auto updateLineEdit = [=, this] { lineEdit->setText(mViewModel->displayPath()); };
+        const auto updateLineEdit = [=, this] { 
+            int cursorPosition = lineEdit->cursorPosition();
+            lineEdit->setText(mViewModel->displayPath()); 
+            lineEdit->setCursorPosition(cursorPosition);
+        };
         updateLineEdit();
         QObject::connect(mViewModel, &RemoteDirectorySelectionWidgetViewModel::pathChanged, this, updateLineEdit);
         QObject::connect(

--- a/src/ui/widgets/torrentremotedirectoryselectionwidget.cpp
+++ b/src/ui/widgets/torrentremotedirectoryselectionwidget.cpp
@@ -100,14 +100,18 @@ namespace tremotesf {
 
         const auto viewModel = qobject_cast<TorrentDownloadDirectoryDirectorySelectionWidgetViewModel*>(mViewModel);
         const auto comboBox = qobject_cast<QComboBox*>(mTextField);
+        comboBox->setCompleter(0);
 
         const auto updateItems = [=] {
             const auto items = viewModel->initialComboBoxItems();
+            int cursorPosition = comboBox->lineEdit()->cursorPosition();
             comboBox->clear();
             for (const auto& [itemPath, itemDisplayPath] : items) {
                 comboBox->addItem(itemDisplayPath, itemPath);
             }
+
             comboBox->lineEdit()->setText(viewModel->displayPath());
+            comboBox->lineEdit()->setCursorPosition(cursorPosition);
         };
         updateItems();
         QObject::connect(


### PR DESCRIPTION
HI.

Found a little bug where the cursor resets when you try to edit file paths. It drives me crazy.
 <details>
 <summary>Take a look</summary>

https://github.com/user-attachments/assets/e69ea0a4-59ed-4524-aefa-c55fae13e22e


 </details>
I wrote a small patch that stabilizes the cursor position while you're editing.  If you have a better or cleaner way to handle the fix, please feel free to use your own implementation.