### PR TITLE
Sort download directory list in set location dialog as directory filter do

### DIFF
--- a/src/ui/widgets/torrentremotedirectoryselectionwidget.cpp
+++ b/src/ui/widgets/torrentremotedirectoryselectionwidget.cpp
@@ -58,6 +58,7 @@ namespace tremotesf {
         QCollator collator{};
         collator.setCaseSensitivity(Qt::CaseInsensitive);
         collator.setNumericMode(true);
+        collator.setIgnorePunctuation(true);
         // QStringList is not compatibly with std::ranges::sort in Qt 5
         std::ranges::sort(directories, [&collator](const QString& first, const QString& second) {
             return collator.compare(first, second) < 0;


### PR DESCRIPTION
# Description

I use directory prefix like `,_=` which is safe for filesystem handling and distinguishable for human eye.
Sort difference between left sidebar directory filter and Set Location dialog directory listing was buggy for me.

# Changes made

Set Set Location directory listing have same sort flag as directory filter do, that is already ignore puntuation by default)
(I forgot exact qt documentation fact-check as this commit made months ago)