### PR TITLE
Don't use static_cast for BaseTorrentFilesModel::Column

### DIFF
--- a/src/ui/itemmodels/basetorrentfilesmodel.cpp
+++ b/src/ui/itemmodels/basetorrentfilesmodel.cpp
@@ -13,6 +13,7 @@
 
 #include "desktoputils.h"
 #include "formatutils.h"
+#include "stdutils.h"
 
 namespace tremotesf {
     BaseTorrentFilesModel::BaseTorrentFilesModel(std::vector<Column>&& columns, QObject* parent)
@@ -25,7 +26,7 @@ namespace tremotesf {
             return {};
         }
         const auto* const entry = static_cast<TorrentFilesModelEntry*>(index.internalPointer());
-        const Column column = mColumns.at(static_cast<size_t>(index.column()));
+        const Column column = fromColumnNumber(index.column());
         switch (role) {
         case Qt::CheckStateRole:
             if (column == Column::Name) {
@@ -87,7 +88,7 @@ namespace tremotesf {
         if (!index.isValid()) {
             return {};
         }
-        if (static_cast<Column>(index.column()) == Column::Name) {
+        if (fromColumnNumber(index.column()) == Column::Name) {
             return QAbstractItemModel::flags(index) | Qt::ItemIsUserCheckable;
         }
         return QAbstractItemModel::flags(index);
@@ -97,7 +98,7 @@ namespace tremotesf {
         if (orientation != Qt::Horizontal || role != Qt::DisplayRole) {
             return {};
         }
-        switch (mColumns.at(static_cast<size_t>(section))) {
+        switch (fromColumnNumber(section)) {
         case Column::Name:
             //: Column title in torrent's file list
             return qApp->translate("tremotesf", "Name");
@@ -122,7 +123,7 @@ namespace tremotesf {
         if (!index.isValid()) {
             return false;
         }
-        if (static_cast<Column>(index.column()) == Column::Name && role == Qt::CheckStateRole) {
+        if (fromColumnNumber(index.column()) == Column::Name && role == Qt::CheckStateRole) {
             setFilesWanted({index}, (value.toInt() == Qt::Checked));
             return true;
         }
@@ -171,7 +172,7 @@ namespace tremotesf {
         class DataChangedDispatcher final {
         public:
             struct ColumnAndRoles {
-                BaseTorrentFilesModel::Column column;
+                int column;
                 QList<int> roles;
             };
 
@@ -207,8 +208,8 @@ namespace tremotesf {
                     const auto emitForRange = [&] {
                         if (mColumnAndRoles.has_value()) {
                             emit model.dataChanged(
-                                model.index(firstRow, static_cast<int>(mColumnAndRoles->column), parent),
-                                model.index(lastRow, static_cast<int>(mColumnAndRoles->column), parent),
+                                model.index(firstRow, mColumnAndRoles->column, parent),
+                                model.index(lastRow, mColumnAndRoles->column, parent),
                                 mColumnAndRoles->roles
                             );
                         } else {
@@ -306,7 +307,7 @@ namespace tremotesf {
     void BaseTorrentFilesModel::setFilesWanted(const QModelIndexList& indexes, bool wanted) {
         setWantedOrPriority(
             indexes,
-            {.column = Column::Name, .roles = {Qt::CheckStateRole}},
+            {.column = columnNumber(Column::Name), .roles = {Qt::CheckStateRole}},
             [&](TorrentFilesModelEntry* entry) { return entry->setWanted(wanted); },
             *this
         );
@@ -316,7 +317,7 @@ namespace tremotesf {
     BaseTorrentFilesModel::setFilesPriority(const QModelIndexList& indexes, TorrentFilesModelEntry::Priority priority) {
         setWantedOrPriority(
             indexes,
-            {.column = Column::Priority, .roles = {Qt::DisplayRole, SortRole}},
+            {.column = columnNumber(Column::Priority), .roles = {Qt::DisplayRole, SortRole}},
             [&](TorrentFilesModelEntry* entry) { return entry->setPriority(priority); },
             *this
         );
@@ -325,6 +326,15 @@ namespace tremotesf {
     void BaseTorrentFilesModel::fileRenamed(TorrentFilesModelEntry* entry, const QString& newName) {
         entry->setName(newName);
         emit dataChanged(createIndex(entry->row(), 0, entry), createIndex(entry->row(), columnCount() - 1, entry));
+    }
+
+    int BaseTorrentFilesModel::columnNumber(Column column) const {
+        // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
+        return indexOfCasted<int>(mColumns, column).value();
+    }
+
+    BaseTorrentFilesModel::Column BaseTorrentFilesModel::fromColumnNumber(int column) const {
+        return mColumns.at(static_cast<size_t>(column));
     }
 
     void BaseTorrentFilesModel::updateFiles(

--- a/src/ui/itemmodels/basetorrentfilesmodel.h
+++ b/src/ui/itemmodels/basetorrentfilesmodel.h
@@ -38,6 +38,9 @@ namespace tremotesf {
         virtual void renameFile(const QModelIndex& index, const QString& newName) = 0;
         void fileRenamed(TorrentFilesModelEntry* entry, const QString& newName);
 
+        Column fromColumnNumber(int column) const;
+        int columnNumber(Column column) const;
+
     protected:
         void updateFiles(
             std::span<const int> changedFiles, std::function<void(size_t, TorrentFilesModelEntry*)>&& updateFile

--- a/src/ui/itemmodels/torrentfilesmodel_test.cpp
+++ b/src/ui/itemmodels/torrentfilesmodel_test.cpp
@@ -29,10 +29,8 @@ namespace tremotesf {
         QModelIndex indexForPath(QLatin1String path, QAbstractItemModel& model) {
             QModelIndex index{};
             for (const auto& part : path.tokenize(u'/')) {
-                const auto childIndexes =
-                    std::views::iota(0, model.rowCount(index)) | std::views::transform([&](int row) {
-                        return model.index(row, static_cast<int>(BaseTorrentFilesModel::Column::Name), index);
-                    });
+                const auto childIndexes = std::views::iota(0, model.rowCount(index))
+                                          | std::views::transform([&](int row) { return model.index(row, 0, index); });
                 const auto found = std::ranges::find(childIndexes, part, [&](const QModelIndex& childIndex) {
                     return childIndex.data().toString();
                 });
@@ -63,18 +61,16 @@ namespace tremotesf {
                 return allColumnsAndRoles(index, index);
             }
 
-            static ExpectedDataChanged specificColumnAndRoles(
-                QModelIndex topLeft, QModelIndex bottomRight, BaseTorrentFilesModel::Column column, QList<int> roles
-            ) {
+            static ExpectedDataChanged
+            specificColumnAndRoles(QModelIndex topLeft, QModelIndex bottomRight, int column, QList<int> roles) {
                 return {
-                    .topLeft = topLeft.siblingAtColumn(static_cast<int>(column)),
-                    .bottomRight = bottomRight.siblingAtColumn(static_cast<int>(column)),
+                    .topLeft = topLeft.siblingAtColumn(column),
+                    .bottomRight = bottomRight.siblingAtColumn(column),
                     .roles = std::move(roles)
                 };
             }
 
-            static ExpectedDataChanged
-            specificColumnAndRoles(QModelIndex index, BaseTorrentFilesModel::Column column, QList<int> roles) {
+            static ExpectedDataChanged specificColumnAndRoles(QModelIndex index, int column, QList<int> roles) {
                 return specificColumnAndRoles(index, index, column, std::move(roles));
             }
         };
@@ -356,35 +352,32 @@ namespace tremotesf {
             model.setFilesWanted({model.index(0, 0)}, false);
 
             const auto actualSignals = actualDataChanged(dataChanged);
+            const int nameColumn = model.columnNumber(BaseTorrentFilesModel::Column::Name);
             const QList<int> expectedRoles{Qt::CheckStateRole};
             const auto expectedSignals = std::set{
                 ExpectedDataChanged::specificColumnAndRoles(
                     indexForPath("topdir/subdir1/subsubddir/file1"_L1, model),
-                    BaseTorrentFilesModel::Column::Name,
+                    nameColumn,
                     expectedRoles
                 ),
                 ExpectedDataChanged::specificColumnAndRoles(
                     indexForPath("topdir/subdir1/subsubddir"_L1, model),
-                    BaseTorrentFilesModel::Column::Name,
+                    nameColumn,
                     expectedRoles
                 ),
                 ExpectedDataChanged::specificColumnAndRoles(
                     indexForPath("topdir/subdir2/file1"_L1, model),
                     indexForPath("topdir/subdir2/file2"_L1, model),
-                    BaseTorrentFilesModel::Column::Name,
+                    nameColumn,
                     expectedRoles
                 ),
                 ExpectedDataChanged::specificColumnAndRoles(
                     indexForPath("topdir/subdir1"_L1, model),
                     indexForPath("topdir/subdir2"_L1, model),
-                    BaseTorrentFilesModel::Column::Name,
+                    nameColumn,
                     expectedRoles
                 ),
-                ExpectedDataChanged::specificColumnAndRoles(
-                    indexForPath("topdir"_L1, model),
-                    BaseTorrentFilesModel::Column::Name,
-                    expectedRoles
-                )
+                ExpectedDataChanged::specificColumnAndRoles(indexForPath("topdir"_L1, model), nameColumn, expectedRoles)
             };
 
             QCOMPARE(actualSignals, expectedSignals);
@@ -454,28 +447,25 @@ namespace tremotesf {
             model.setFilesWanted({indexForPath("topdir/subdir1/subsubddir/file2"_L1, model)}, true);
 
             const auto actualSignals = actualDataChanged(dataChanged);
+            const int nameColumn = model.columnNumber(BaseTorrentFilesModel::Column::Name);
             const QList<int> expectedRoles{Qt::CheckStateRole};
             const auto expectedSignals = std::set{
                 ExpectedDataChanged::specificColumnAndRoles(
                     indexForPath("topdir/subdir1/subsubddir/file2"_L1, model),
-                    BaseTorrentFilesModel::Column::Name,
+                    nameColumn,
                     expectedRoles
                 ),
                 ExpectedDataChanged::specificColumnAndRoles(
                     indexForPath("topdir/subdir1/subsubddir"_L1, model),
-                    BaseTorrentFilesModel::Column::Name,
+                    nameColumn,
                     expectedRoles
                 ),
                 ExpectedDataChanged::specificColumnAndRoles(
                     indexForPath("topdir/subdir1"_L1, model),
-                    BaseTorrentFilesModel::Column::Name,
+                    nameColumn,
                     expectedRoles
                 ),
-                ExpectedDataChanged::specificColumnAndRoles(
-                    indexForPath("topdir"_L1, model),
-                    BaseTorrentFilesModel::Column::Name,
-                    expectedRoles
-                )
+                ExpectedDataChanged::specificColumnAndRoles(indexForPath("topdir"_L1, model), nameColumn, expectedRoles)
             };
             QCOMPARE(actualSignals, expectedSignals);
 
@@ -544,33 +534,34 @@ namespace tremotesf {
             model.setFilesPriority({model.index(0, 0)}, TorrentFilesModelEntry::Priority::Low);
 
             const auto actualSignals = actualDataChanged(dataChanged);
+            const int priorityColumn = model.columnNumber(BaseTorrentFilesModel::Column::Priority);
             const QList<int> expectedRoles{Qt::DisplayRole, BaseTorrentFilesModel::SortRole};
             const auto expectedSignals = std::set{
                 ExpectedDataChanged::specificColumnAndRoles(
                     indexForPath("topdir/subdir1/subsubddir/file1"_L1, model),
-                    BaseTorrentFilesModel::Column::Priority,
+                    priorityColumn,
                     expectedRoles
                 ),
                 ExpectedDataChanged::specificColumnAndRoles(
                     indexForPath("topdir/subdir1/subsubddir"_L1, model),
-                    BaseTorrentFilesModel::Column::Priority,
+                    priorityColumn,
                     expectedRoles
                 ),
                 ExpectedDataChanged::specificColumnAndRoles(
                     indexForPath("topdir/subdir2/file1"_L1, model),
                     indexForPath("topdir/subdir2/file2"_L1, model),
-                    BaseTorrentFilesModel::Column::Priority,
+                    priorityColumn,
                     expectedRoles
                 ),
                 ExpectedDataChanged::specificColumnAndRoles(
                     indexForPath("topdir/subdir1"_L1, model),
                     indexForPath("topdir/subdir2"_L1, model),
-                    BaseTorrentFilesModel::Column::Priority,
+                    priorityColumn,
                     expectedRoles
                 ),
                 ExpectedDataChanged::specificColumnAndRoles(
                     indexForPath("topdir"_L1, model),
-                    BaseTorrentFilesModel::Column::Priority,
+                    priorityColumn,
                     expectedRoles
                 )
             };
@@ -644,26 +635,27 @@ namespace tremotesf {
             );
 
             const auto actualSignals = actualDataChanged(dataChanged);
+            const int priorityColumn = model.columnNumber(BaseTorrentFilesModel::Column::Priority);
             const QList<int> expectedRoles{Qt::DisplayRole, BaseTorrentFilesModel::SortRole};
             const auto expectedSignals = std::set{
                 ExpectedDataChanged::specificColumnAndRoles(
                     indexForPath("topdir/subdir1/subsubddir/file2"_L1, model),
-                    BaseTorrentFilesModel::Column::Priority,
+                    priorityColumn,
                     expectedRoles
                 ),
                 ExpectedDataChanged::specificColumnAndRoles(
                     indexForPath("topdir/subdir1/subsubddir"_L1, model),
-                    BaseTorrentFilesModel::Column::Priority,
+                    priorityColumn,
                     expectedRoles
                 ),
                 ExpectedDataChanged::specificColumnAndRoles(
                     indexForPath("topdir/subdir1"_L1, model),
-                    BaseTorrentFilesModel::Column::Priority,
+                    priorityColumn,
                     expectedRoles
                 ),
                 ExpectedDataChanged::specificColumnAndRoles(
                     indexForPath("topdir"_L1, model),
-                    BaseTorrentFilesModel::Column::Priority,
+                    priorityColumn,
                     expectedRoles
                 )
             };

--- a/src/ui/widgets/torrentfilesview.cpp
+++ b/src/ui/widgets/torrentfilesview.cpp
@@ -36,13 +36,13 @@ namespace tremotesf {
           mLocalFile(true),
           mModel(model),
           mProxyModel(new TorrentFilesProxyModel(
-              mModel, LocalTorrentFilesModel::SortRole, static_cast<int>(LocalTorrentFilesModel::Column::Name), this
+              mModel, LocalTorrentFilesModel::SortRole, model->columnNumber(BaseTorrentFilesModel::Column::Name), this
           )),
           mRpc(rpc) {
         init();
         setItemDelegate(new TooltipWhenElidedDelegate(this));
         if (!header()->restoreState(Settings::instance()->get_localTorrentFilesViewHeaderState())) {
-            sortByColumn(static_cast<int>(LocalTorrentFilesModel::Column::Name), Qt::AscendingOrder);
+            sortByColumn(model->columnNumber(BaseTorrentFilesModel::Column::Name), Qt::AscendingOrder);
         }
     }
 
@@ -51,17 +51,17 @@ namespace tremotesf {
           mLocalFile(false),
           mModel(model),
           mProxyModel(new TorrentFilesProxyModel(
-              mModel, TorrentFilesModel::SortRole, static_cast<int>(TorrentFilesModel::Column::Name), this
+              mModel, TorrentFilesModel::SortRole, model->columnNumber(BaseTorrentFilesModel::Column::Name), this
           )),
           mRpc(rpc) {
         init();
         setItemDelegate(new TooltipWhenElidedDelegate(this));
         setItemDelegateForColumn(
-            static_cast<int>(TorrentFilesModel::Column::ProgressBar),
+            model->columnNumber(BaseTorrentFilesModel::Column::ProgressBar),
             new ProgressBarDelegate(TorrentFilesModel::SortRole, this)
         );
         if (!header()->restoreState(Settings::instance()->get_torrentFilesViewHeaderState())) {
-            sortByColumn(static_cast<int>(TorrentFilesModel::Column::Name), Qt::AscendingOrder);
+            sortByColumn(model->columnNumber(BaseTorrentFilesModel::Column::Name), Qt::AscendingOrder);
         }
 
         QObject::connect(this, &TorrentFilesView::activated, this, [=, this](const auto& index) {


### PR DESCRIPTION
BaseTorrentFilesModel::Column enum entries don't necessarily equal actual column numbers, we need to always go through mColumns.